### PR TITLE
Fix notices for resources base or block cost not set closes #14

### DIFF
--- a/bookings-helper.php
+++ b/bookings-helper.php
@@ -486,7 +486,7 @@ if ( ! class_exists( 'Bookings_Helper' ) ) {
 						$wpdb->insert(
 							$wpdb->prefix . 'wc_bookings_availability',
 							array(
-								'gcal_event_id' => $rule['gcal_event_id'],
+								'gcal_event_id' => ! empty( $rule['gcal_event_id'] ) ? $rule['gcal_event_id'] : '',
 								'title'         => $rule['title'],
 								'range_type'    => $rule['range_type'],
 								'from_date'     => $rule['from_date'],
@@ -498,7 +498,7 @@ if ( ! class_exists( 'Bookings_Helper' ) ) {
 								'ordering'      => $rule['ordering'],
 								'date_created'  => $rule['date_created'],
 								'date_modified' => $rule['date_modified'],
-								'rrule'         => $rule['rrule'],
+								'rrule'         => ! empty( $rule['rrule'] ) ? $rule['rrule'] : '',
 							),
 							array(
 								'%s',
@@ -689,8 +689,8 @@ if ( ! class_exists( 'Bookings_Helper' ) ) {
 							$wpdb->query( $wpdb->prepare( "INSERT INTO {$wpdb->postmeta} ( post_id, meta_key, meta_value ) VALUES ( %d, %s, %s )", $resource_id, sanitize_text_field( $meta['meta_key'] ), sanitize_text_field( $meta['meta_value'] ) ) );		
 						}
 
-						$new_resource_base_costs[ $resource_id ]  = $resource_base_costs[ $resource['resource']['ID'] ];
-						$new_resource_block_costs[ $resource_id ] = $resource_block_costs[ $resource['resource']['ID'] ];
+						$new_resource_base_costs[ $resource_id ]  = ! empty( $resource_base_costs ) ? $resource_base_costs[ $resource['resource']['ID'] ] : '';
+						$new_resource_block_costs[ $resource_id ] = ! empty( $resource_block_costs ) ? $resource_block_costs[ $resource['resource']['ID'] ] : '';
 
 						$wpdb->query( $wpdb->prepare( "INSERT INTO {$wpdb->prefix}wc_booking_relationships ( product_id, resource_id ) VALUES ( %d, %d )", $product_id, $resource_id ) );
 					}

--- a/bookings-helper.php
+++ b/bookings-helper.php
@@ -689,9 +689,8 @@ if ( ! class_exists( 'Bookings_Helper' ) ) {
 							$wpdb->query( $wpdb->prepare( "INSERT INTO {$wpdb->postmeta} ( post_id, meta_key, meta_value ) VALUES ( %d, %s, %s )", $resource_id, sanitize_text_field( $meta['meta_key'] ), sanitize_text_field( $meta['meta_value'] ) ) );		
 						}
 
-						$new_resource_base_costs[ $resource_id ]  = ! empty( $resource_base_costs ) ? $resource_base_costs[ $resource['resource']['ID'] ] : '';
-						$new_resource_block_costs[ $resource_id ] = ! empty( $resource_block_costs ) ? $resource_block_costs[ $resource['resource']['ID'] ] : '';
-
+						$new_resource_base_costs[ $resource_id ]  = ! empty( $resource_base_costs[ $resource['resource']['ID'] ] ) ? $resource_base_costs[ $resource['resource']['ID'] ] : '';
+						$new_resource_block_costs[ $resource_id ] = ! empty( $resource_block_costs[ $resource['resource']['ID'] ] ) ? $resource_block_costs[ $resource['resource']['ID'] ] : '';
 						$wpdb->query( $wpdb->prepare( "INSERT INTO {$wpdb->prefix}wc_booking_relationships ( product_id, resource_id ) VALUES ( %d, %d )", $product_id, $resource_id ) );
 					}
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 2019-xx-xx - version 1.0.3
 * Add - Compatibility with Bookings custom global availability tables.
+* Fix - Notices when importing products with resources and no set block/base costs.
 
 2017-09-06 - version 1.0.2
 * Add - Import/Export of zip file when ZipArchive extension is installed.


### PR DESCRIPTION
Fixes #14 

* Fix - Notices when importing products with resources and no set block/base costs.

Testing steps:
* Go to the tools->bookings helper
* Import a product with bookings resources with no base/block cost.
* After import make sure there are no PHP notices.