### PR TITLE
Enhancement/23 Code Cleanup + Min Version Bumps + PHP Compat Testing

### DIFF
--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set PHP version
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: 7.0
           tools: composer:v2
           coverage: none
 
@@ -28,4 +28,4 @@ jobs:
         run: composer install
 
       - name: Run PHP Compatibility
-        run: ./vendor/bin/phpcs *.php includes -p --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 7.2-
+        run: ./vendor/bin/phpcs *.php includes -p --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 7.0-

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -1,0 +1,31 @@
+name: PHP Compatibility
+
+on:
+  push:
+    branches:
+      - trunk
+  pull_request:
+    branches:
+      - trunk
+
+jobs:
+  php_compatibility:
+    name: PHP minimum 7.0
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set PHP version
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.4
+          tools: composer:v2
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install
+
+      - name: Run PHP Compatibility
+        run: ./vendor/bin/phpcs *.php includes -p --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 7.2-

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+/node_modules/
+.DS_Store
+.vscode
+/languages/
+
+# Ignore all log files except for .htaccess
+/logs/*
+!/logs/.htaccess
+
+/vendor/
+composer.lock

--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@ This extension is a WooCommerce Bookings helper which helps you to troubleshoot 
 
 All exports will be in JSON file format zipped.
 
+# Minimum Version Requirements
+
+* WordPress 5.6
+* WooCommerce 6.0
+* PHP 7.2
+
 # Global Availability Rules
 
 Importing global availability rules will overwrite all the rules. This is because a bookable product test case will depend on these rules. Since this is an overwriting feature, you can first export the global availability rules for safe keeping before you import your test rules. This way you can always import back your original rules.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ All exports will be in JSON file format zipped.
 
 * WordPress 5.6
 * WooCommerce 6.0
-* PHP 7.2
+* PHP 7.0
 
 # Global Availability Rules
 

--- a/bookings-helper.php
+++ b/bookings-helper.php
@@ -17,7 +17,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+if ( ! defined( 'WC_BOOKINGS_ABSPATH' ) ) {
+	define( 'WC_BOOKINGS_HELPER_ABSPATH', dirname( __FILE__ ) . '/' );
+}
+
 if ( ! class_exists( 'Bookings_Helper' ) ) {
+
+	define( 'WC_BOOKINGS_HELPER_VERSION', '1.0.4' );
+	define( 'WC_BOOKINGS_HELPER_TEMPLATE_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) . '/templates/' );
+	define( 'WC_BOOKINGS_HELPER_PLUGIN_URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
+	define( 'WC_BOOKINGS_HELPER_PLUGIN_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
+	define( 'WC_BOOKINGS_HELPER_MAIN_FILE', __FILE__ );
+
 	/**
 	 * Main class.
 	 *
@@ -27,42 +38,24 @@ if ( ! class_exists( 'Bookings_Helper' ) ) {
 	 */
 	class Bookings_Helper {
 		/**
-		 * Temporary directory path.
-		 *
-		 * @since 1.0.2
-		 * @version 1.0.2
-		 * @var
-		 */
-		public $temp_dir;
-
-		/**
-		 * Notices.
-		 *
-		 * @since 1.0.0
-		 * @version 1.0.0
-		 * @var
-		 */
-		public $notice;
-
-		/**
-		 * Checks to see if ZipArchive library exists.
-		 *
-		 * @since 1.0.2
-		 * @version 1.0.2
-		 * @var
-		 */
-		public $ziparchive_available;
-
-		/**
 		 * Constructor.
 		 *
 		 * @since 1.0.0
 		 * @version 1.0.2
 		 */
 		public function __construct() {
-			$this->temp_dir              = get_temp_dir() . 'bookings-helper';
-			$this->ziparchive_available  = class_exists( 'ZipArchive' ) ? true : false;
+			$this->includes();
 			$this->init();
+		}
+
+		/**
+		 * Load Classes.
+		 */
+		public function includes() {
+			require_once WC_BOOKINGS_HELPER_ABSPATH . 'includes/wc-bookings-helper-functions.php';
+			require_once WC_BOOKINGS_HELPER_ABSPATH . 'includes/class-wc-bookings-helper-utils.php';
+			require_once WC_BOOKINGS_HELPER_ABSPATH . 'includes/class-wc-bookings-helper-export.php';
+			require_once WC_BOOKINGS_HELPER_ABSPATH . 'includes/class-wc-bookings-helper-import.php';
 		}
 
 		/**
@@ -73,7 +66,6 @@ if ( ! class_exists( 'Bookings_Helper' ) ) {
 		 */
 		public function init() {
 			add_action( 'admin_menu', array( $this, 'add_submenu_page' ) );
-			add_action( 'init', array( $this, 'catch_requests' ), 20 );
 		}
 
 		/**
@@ -93,676 +85,112 @@ if ( ! class_exists( 'Bookings_Helper' ) ) {
 		 * @version 1.0.0
 		 */
 		public function tool_page() {
-			if ( ! empty( $this->notice ) ) {
-				echo $this->notice;
-			}
-
-			$file_label = $this->ziparchive_available ? 'ZIP' : 'JSON';
+			$ziparchive_available = class_exists( 'ZipArchive' );
+			$file_label           = $ziparchive_available ? 'ZIP' : 'JSON';
 			?>
-			<div class="wrap">
-				<h1>Bookings Helper</h1>
-				<hr />
-				<div>
-					<h3>Global Availability Rules</h3>
+            <div class="wrap">
+                <h1>Bookings Helper</h1>
+                <hr/>
+                <div>
+                    <h3>Global Availability Rules</h3>
 					<?php
 					$action_url = add_query_arg( array( 'page' => 'bookings-helper' ), admin_url( 'tools.php' ) );
 					?>
-					<form action="<?php echo $action_url; ?>" method="post" style="margin-bottom:20px;border:1px solid #ccc;padding:5px;">
-						<table>
-							<tr>
-								<td>
-									<input type="submit" class="button" value="Export Rules" /> <label>Exports all global availability rules.</label>
-									<input type="hidden" name="action" value="export_globals" />
+                    <form action="<?php echo $action_url; ?>" method="post" style="margin-bottom:20px;border:1px solid #ccc;padding:5px;">
+                        <table>
+                            <tr>
+                                <td>
+                                    <input type="submit" class="button" value="Export Rules"/> <label>Exports all global availability rules.</label>
+                                    <input type="hidden" name="action" value="export_globals"/>
 									<?php wp_nonce_field( 'export_globals' ); ?>
-								</td>
-							</tr>
-						</table>
-					</form>
+                                </td>
+                            </tr>
+                        </table>
+                    </form>
 
 					<?php
 					$action_url = add_query_arg( array( 'page' => 'bookings-helper' ), admin_url( 'tools.php' ) );
 					?>
-					<form enctype="multipart/form-data" action="<?php echo $action_url; ?>" method="post" style="margin-bottom:20px;border:1px solid #ccc;padding:5px;">
-						<table>
-							<tr>
-								<td>
-									<label>Choose a file (<?php echo $file_label; ?>).</label><input type="file" name="import" />
-								</td>
-							</tr>
+                    <form enctype="multipart/form-data" action="<?php echo $action_url; ?>" method="post" style="margin-bottom:20px;border:1px solid #ccc;padding:5px;">
+                        <table>
+                            <tr>
+                                <td>
+                                    <label>Choose a file (<?php echo $file_label; ?>).</label><input type="file" name="import"/>
+                                </td>
+                            </tr>
 
-							<tr>
-								<td>
-									<input type="submit" class="button" value="Import Rules" /> <label>Imports global availability rules replacing your current rules.</label>
-									<input type="hidden" name="action" value="import_globals" />
+                            <tr>
+                                <td>
+                                    <input type="submit" class="button" value="Import Rules"/> <label>Imports global availability rules replacing your current rules.</label>
+                                    <input type="hidden" name="action" value="import_globals"/>
 									<?php wp_nonce_field( 'import_globals' ); ?>
-								</td>
-							</tr>
-						</table>
-					</form>
+                                </td>
+                            </tr>
+                        </table>
+                    </form>
 
-					<h3>Booking Products</h3>
+                    <h3>Booking Products</h3>
 					<?php
 					$action_url = add_query_arg( array( 'page' => 'bookings-helper' ), admin_url( 'tools.php' ) );
 					?>
-					<form action="<?php echo $action_url; ?>" method="post" style="margin-bottom:20px;border:1px solid #ccc;padding:5px;">
-						<table>
-							<tr>
-								<td>
-									<label>Product ID: <input type="number" name="product_id" min="1" /></label>
-									<input type="submit" class="button" value="Export Booking Product" /> <label>Exports a specific Booking product and its settings including resources.</label>
-									<input type="hidden" name="action" value="export_product" />
+                    <form action="<?php echo $action_url; ?>" method="post" style="margin-bottom:20px;border:1px solid #ccc;padding:5px;">
+                        <table>
+                            <tr>
+                                <td>
+                                    <label>Product ID: <input type="number" name="product_id" min="1"/></label>
+                                    <input type="submit" class="button" value="Export Booking Product"/> <label>Exports a specific Booking product and its settings including resources.</label>
+                                    <input type="hidden" name="action" value="export_product"/>
 									<?php wp_nonce_field( 'export_product' ); ?>
-								</td>
-							</tr>
-						</table>
-					</form>
+                                </td>
+                            </tr>
+                        </table>
+                    </form>
 
 					<?php
 					$action_url = add_query_arg( array( 'page' => 'bookings-helper' ), admin_url( 'tools.php' ) );
 					?>
-					<form enctype="multipart/form-data" action="<?php echo $action_url; ?>" method="post" style="margin-bottom:20px;border:1px solid #ccc;padding:5px;">
-						<table>
-							<tr>
-								<td>
-									<label>Choose a file (<?php echo $file_label; ?>).</label><input type="file" name="import" />
-								</td>
-							</tr>
+                    <form enctype="multipart/form-data" action="<?php echo $action_url; ?>" method="post" style="margin-bottom:20px;border:1px solid #ccc;padding:5px;">
+                        <table>
+                            <tr>
+                                <td>
+                                    <label>Choose a file (<?php echo $file_label; ?>).</label><input type="file" name="import"/>
+                                </td>
+                            </tr>
 
-							<tr>
-								<td>
-									<input type="submit" class="button" value="Import Product" /> <label>Imports a booking product.</label>
-									<input type="hidden" name="action" value="import_product" />
+                            <tr>
+                                <td>
+                                    <input type="submit" class="button" value="Import Product"/> <label>Imports a booking product.</label>
+                                    <input type="hidden" name="action" value="import_product"/>
 									<?php wp_nonce_field( 'import_product' ); ?>
-								</td>
-							</tr>
-						</table>
-					</form>	
-				</div>
-			</div>
+                                </td>
+                            </tr>
+                        </table>
+                    </form>
+                </div>
+            </div>
 			<?php
 
-			if ( ! $this->ziparchive_available ) {
+			if ( ! $ziparchive_available ) {
 				echo '<div><p><strong style="color:red;">PHP ZipArchive extension is not installed. Import/Export will be in JSON format.</strong></p></div>';
 			}
 		}
 
-		/**
-		 * Catches form requests.
-		 *
-		 * @since 1.0.0
-		 * @version 1.0.0
-		 */
-		public function catch_requests() {
-			if ( ! isset( $_GET['page'] ) || 'bookings-helper' !== $_GET['page'] ) {
-				return;
-			}
-
-			if ( ! isset( $_POST['action'] ) || ! isset( $_POST['_wpnonce'] ) ) {
-				return;
-			}
-
-			if (
-				'export_globals' !== $_POST['action'] &&
-				'import_globals' !== $_POST['action'] &&
-				'export_product' !== $_POST['action'] &&
-				'import_product' !== $_POST['action']
-			) {
-				return;
-			}
-
-			if (
-				! wp_verify_nonce( $_POST['_wpnonce'], 'export_globals' ) &&
-				! wp_verify_nonce( $_POST['_wpnonce'], 'import_globals' ) &&
-				! wp_verify_nonce( $_POST['_wpnonce'], 'export_product' ) &&
-				! wp_verify_nonce( $_POST['_wpnonce'], 'import_product' )
-			) {
-				wp_die( 'Cheatin&#8217; huh?' );
-			}
-
-			switch ( $_POST['action'] ) {
-				case 'export_globals':
-					$this->export_global_rules();
-					break;
-				
-				case 'import_globals':
-					$this->import_global_rules();
-					break;
-				
-				case 'export_product':
-					$this->export_product();
-					break;
-				
-				case 'import_product':
-					$this->import_product();
-					break;
-			}
-		}
-
-		/**
-		 * Prepares the directory for file transfer.
-		 *
-		 * @since 1.0.2
-		 * @version 1.0.2
-		 */
-		public function prep_transfer() {
-			if ( ! is_dir( $this->temp_dir ) ) {
-				return mkdir( $this->temp_dir );
-			}
-		}
-
-		/**
-		 * Cleans up lingering files and folder during transfer.
-		 *
-		 * @since 1.0.2
-		 * @version 1.0.2
-		 */
-		public function clean_up( $path = null ) {
-			if ( null === $path ) {
-				$path = $this->temp_dir;
-			}
-
-			if ( is_dir( $path ) ) {
-				$objects = scandir( $path );
-
-				foreach ( $objects as $object ) {
-					if ( '.' !== $object && '..' !== $object ) {
-						if ( is_dir( $path . '/' . $object ) ) {
-							$this->clean_up( $path . '/' . $object );
-						} else {
-							unlink( $path . '/' . $object );
-						}
-					}
-				}
-
-				rmdir( $path );
-			}
-		}
-
-		/**
-		 * Creates the zip file.
-		 *
-		 * @since 1.0.2
-		 * @version 1.0.2
-		 * @param JSON string $data | Data to be zipped
-		 * @param string $filename
-		 */
-		public function create_zip( $data = false, $filename ) {
-			$zip_file = $this->temp_dir . '/' . $filename . '.zip';
-
-			$zip = new ZipArchive();
-			$zip->open( $zip_file, ZIPARCHIVE::CREATE | ZIPARCHIVE::OVERWRITE );
-			$zip->addFromString( $filename . '.json', $data );
-			$zip->close();
-
-			if ( file_exists( $this->temp_dir . '/' . $filename . '.zip' ) ) {
-				return true;
-			}
-
-			return false;
-		}
-
-		/**
-		 * Opens the zip file.
-		 *
-		 * @since 1.0.2
-		 * @version 1.0.2
-		 */
-		public function open_zip() {
-			$zip = new ZipArchive();
-
-			if ( true === $zip->open( $_FILES['import']['tmp_name'] ) ) {
-				$zip->extractTo( $this->temp_dir );
-				$zip->close();
-
-				$dir       = scandir( $this->temp_dir );
-				$json_file = '';
-
-				/**
-				 * The zip may or may not contain other hidden
-				 * system files so we must only extract the .json file.
-				 */
-				foreach ( $dir as $file ) {
-					if ( preg_match( '/.json/', $file ) ) {
-						$json_file = $file;
-						break;
-					}
-				}
-
-				if ( ! file_exists( $this->temp_dir . '/' . $json_file ) ) {
-					throw new Exception( 'Unable to open zip file' );
-				}
-
-				return file_get_contents( $this->temp_dir . '/' . $json_file );
-			} else {
-				throw new Exception( 'Unable to open zip file' );
-			}
-		}
-
-		/**
-		 * Renders the HTTP headers
-		 *
-		 * @since 1.0.2
-		 * @version 1.0.2
-		 * @param string $filename | Path to file
-		 */
-		public function render_headers( $filename ) {
-			$type = 'json';
-
-			if ( $this->ziparchive_available ) {
-				$type = 'zip';
-			}
-
-			header( 'Content-Type: application/' . $type . '; charset=UTF-8' );
-			header( 'Content-Disposition: attachment; filename=' . $filename . '.' . $type );
-			header( 'Pragma: no-cache' );
-			header( 'Expires: 0' );
-		}
-
-		/**
-		 * Triggers the download feature of the browser.
-		 *
-		 * @since 1.0.0
-		 * @version 1.0.0
-		 * @param string $data
-		 * @param string $prefix
-		 */
-		public function trigger_download( $data = '', $prefix = '' ) {
-			if ( empty( $data ) ) {
-				return;
-			}
-
-			@set_time_limit(0);
-
-			// Disable GZIP
-			if ( function_exists( 'apache_setenv' ) ) {
-				@apache_setenv( 'no-gzip', 1 );
-			}
-
-			@ini_set( 'zlib.output_compression', 'Off' );
-			@ini_set( 'output_buffering', 'Off' );
-			@ini_set( 'output_handler', '' );
-
-			$filename_prefix = $prefix;
-
-			if ( $this->ziparchive_available ) {
-				$filename = sprintf( '%1$s-%2$s', $filename_prefix, date( 'Y-m-d', current_time( 'timestamp' ) ) );
-
-				$this->prep_transfer();
-
-				$this->render_headers( $filename );
-
-				if ( $this->create_zip( $data, $filename ) ) {
-					readfile( $this->temp_dir . '/' . $filename . '.zip' );
-
-					$this->clean_up();
-
-					exit;
-				} else {
-					throw new Exception( 'Unable to export!' );
-				}
-			} else {
-				$filename = sprintf( '%1$s-%2$s.json', $filename_prefix, date( 'Y-m-d', current_time( 'timestamp' ) ) );
-
-				$this->render_headers( $filename );
-
-				file_put_contents( 'php://output', $data );
-
-				exit;
-			}
-		}
-
-		/**
-		 * Exports global availability rules file for browser download.
-		 *
-		 * @since 1.0.0
-		 * @param 1.0.0
-		 */
-		public function export_global_rules() {
-			try {
-				if ( version_compare( WC_BOOKINGS_VERSION, '1.13.0', '<' ) ) {
-					$global_rules = get_option( 'wc_global_booking_availability', array() );
-				} else {
-					$global_rules = WC_Data_Store::load( 'booking-global-availability' )->get_all_as_array();
-				}
-
-				if ( empty( $global_rules ) ) {
-					throw new Exception( 'There are no rules to export.' );					
-				}
-
-				$global_rules_json = json_encode( $global_rules );
-
-				$this->trigger_download( $global_rules_json, 'bookings-global-rules' );
-			} catch ( Exception $e ) {
-				$this->print_notice( $e->getMessage() );
-
-				return;
-			}
-		}
-
-		/**
-		 * Imports global availability rules from file.
-		 *
-		 * @since 1.0.3 Add compatibility with Bookings custom global availability tables.
-		 */
-		public function import_global_rules() {
-			try {
-				if ( empty( $_FILES ) || empty( $_FILES['import'] ) || 0 !== $_FILES['import']['error'] || empty( $_FILES['import']['tmp_name'] ) ) {
-					throw new Exception( 'There are no rules to import or file is not valid.' );
-				} else {
-					if ( $_FILES['import']['size'] > 1000000 ) {
-						throw new Exception( 'The file exceeds 1MB.' );
-					}
-
-					if ( $this->ziparchive_available ) {
-						$global_rules_json = $this->open_zip();
-					} else {
-						$global_rules_json = file_get_contents( $_FILES['import']['tmp_name'] );
-					}
-
-					if ( ! $this->is_json( $global_rules_json ) ) {
-						throw new Exception( 'The file is not in a valid JSON format.' );
-					}
-				}
-
-				$global_rules = json_decode( $global_rules_json, true );
-
-				// Sanitize.
-				array_walk_recursive( $global_rules, 'wc_clean' );
-
-				if ( version_compare( WC_BOOKINGS_VERSION, '1.13.0', '<' ) ) {
-					/*
-					 * For some strange reason update_option is not working here so
-					 * had to revert to delete the option and add it again.
-					 */
-					delete_option( 'wc_global_booking_availability' );
-					add_option( 'wc_global_booking_availability', $global_rules );
-				} else {
-					global $wpdb;
-
-					// First delete all data from table.
-					$wpdb->query( "TRUNCATE TABLE {$wpdb->prefix}wc_bookings_availability" );
-
-					foreach ( $global_rules as $rule ) {
-						$wpdb->insert(
-							$wpdb->prefix . 'wc_bookings_availability',
-							array(
-								'gcal_event_id' => ! empty( $rule['gcal_event_id'] ) ? $rule['gcal_event_id'] : '',
-								'title'         => $rule['title'],
-								'range_type'    => $rule['range_type'],
-								'from_date'     => $rule['from_date'],
-								'to_date'       => $rule['to_date'],
-								'from_range'    => $rule['from_range'],
-								'to_range'      => $rule['to_range'],
-								'bookable'      => $rule['bookable'],
-								'priority'      => $rule['priority'],
-								'ordering'      => $rule['ordering'],
-								'date_created'  => $rule['date_created'],
-								'date_modified' => $rule['date_modified'],
-								'rrule'         => ! empty( $rule['rrule'] ) ? $rule['rrule'] : '',
-							),
-							array(
-								'%s',
-								'%s',
-								'%s',
-								'%s',
-								'%s',
-								'%s',
-								'%s',
-								'%s',
-								'%d',
-								'%d',
-								'%s',
-								'%s',
-							)
-						);
-					}
-				}
-
-				$this->print_notice( 'Global Availability Rules imported successfully!', 'success' );
-				$this->clean_up();
-
-				return;
-			} catch ( Exception $e ) {
-				$this->print_notice( $e->getMessage() );
-
-				return;
-			}
-		}
-
-		/**
-		 * Exports a specific product by ID.
-		 *
-		 * @since 1.0.0
-		 * @version 1.0.1
-		 */
-		public function export_product() {
-			try {
-				$product_id     = isset( $_POST['product_id'] ) ? absint( $_POST['product_id'] ) : '';
-				$product_status = get_post_status( $product_id );
-				
-				if ( empty( $product_id ) || empty( $product_status ) ) {
-					throw new Exception( 'This booking product does not exist!' );
-				}
-
-				global $wpdb;
-
-				// Products.
-				$product = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->posts} WHERE post_type = 'product' AND ID = %d", $product_id ), ARRAY_A );
-
-				// Get the type of the product, accomm or booking.
-				$product_type       = wp_get_post_terms( $product[0]['ID'], 'product_type' );
-				$product[0]['type'] = $product_type[0]->name;
-
-				if ( empty( $product ) ) {
-					throw new Exception( 'This booking product does not exist!' );
-				}
-
-				// Product metas.
-				$product_meta = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->postmeta} WHERE post_id = %d AND ( meta_key LIKE '%%wc_booking%%' OR meta_key = '_resource_base_costs' OR meta_key = '_resource_block_costs' OR meta_key = '_wc_display_cost' OR meta_key = '_virtual' )", $product_id ), ARRAY_A );
-
-				if ( empty( $product_meta ) ) {
-					throw new Exception( 'This booking product does not exist!' );
-				}
-
-				// Booking relationships ( resources ).
-				$resources = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}wc_booking_relationships WHERE product_id = %d", $product_id ), ARRAY_A );
-
-				$prepared_resources = array();
-				$prepared_persons   = array();
-
-				// If resources exists, we need to extract the meta
-				// information for each resource.
-				if ( ! empty( $resources ) ) {
-					foreach ( $resources as $key => $value ) {
-						$resource = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->posts} WHERE post_type = 'bookable_resource' AND ID = %d", $value['resource_id'] ), ARRAY_A );
-
-						if ( ! empty( $resource ) ) {
-							$resource_meta = $wpdb->get_results( $wpdb->prepare( "SELECT meta_key, meta_value FROM {$wpdb->postmeta} WHERE post_id = %d AND ( meta_key = 'qty' OR meta_key = '_wc_booking_availability' )", $value['resource_id'] ), ARRAY_A );
-						}
-
-						$prepared_resources[] = array( 'resource' => $resource[0], 'resource_meta' => $resource_meta );
-					}
-				}
-
-				// Persons.
-				$persons = $wpdb->get_results( $wpdb->prepare( "SELECT ID, post_title, post_excerpt FROM {$wpdb->posts} WHERE post_type = 'bookable_person' AND post_parent = %d", $product_id ), ARRAY_A );
-
-				if ( ! empty( $persons ) ) {
-					foreach ( $persons as $person ) {
-						$person_meta = $wpdb->get_results( $wpdb->prepare( "SELECT meta_key, meta_value FROM {$wpdb->postmeta} WHERE post_id = %d", $person['ID'] ), ARRAY_A );
-
-						$prepared_persons[] = array( 'person' => $person, 'person_meta' => $person_meta );
-					}
-				}
-
-				$prepared_json = json_encode( array( 
-					'product'      => $product[0], 
-					'product_meta' => $product_meta,
-					'resources'    => $prepared_resources,
-					'persons'      => $prepared_persons,
-				) );
-
-				$this->trigger_download( $prepared_json, 'booking-product-' . $product_id );
-			} catch ( Exception $e ) {
-				$this->print_notice( $e->getMessage() );
-
-				return;
-			}
-		}
-
-		/**
-		 * Imports booking product from file.
-		 *
-		 * @since 1.0.0
-		 * @version 1.0.1
-		 */
-		public function import_product() {
-			try {
-				if ( empty( $_FILES ) || empty( $_FILES['import'] ) || 0 !== $_FILES['import']['error'] || empty( $_FILES['import']['tmp_name'] ) ) {
-					throw new Exception( 'There is no bookable product to import or file is not valid.' );
-				} else {
-					if ( $_FILES['import']['size'] > 1000000 ) {
-						throw new Exception( 'The file exceeds 1MB.' );
-					}
-
-					if ( $this->ziparchive_available ) {
-						$product_json = $this->open_zip();
-					} else {
-						$product_json = file_get_contents( $_FILES['import']['tmp_name'] );
-					}
-
-					if ( ! $this->is_json( $product_json ) ) {
-						throw new Exception( 'The file is not in a valid JSON format.' );
-					}
-				}
-
-				$product = json_decode( $product_json, true );
-
-				// Sanitize.
-				array_walk_recursive( $product, 'wc_clean' );
-
-				global $wpdb;
-
-				// Product.
-				$product_data = array( 
-					'post_title'   => sanitize_text_field( $product['product']['post_title'] ) . ' (bookings test #' . absint( $product['product']['ID'] ) . ')',
-					'post_content' => sanitize_text_field( $product['product']['post_content'] ),
-					'post_type'    => 'product',
-					'post_status'  => 'publish',
-				);
-
-				$product_id = wp_insert_post( $product_data, false );
-
-				if ( empty( $product_id ) ) {
-					throw new Exception( 'Failed to create product.' );
-				}
-
-				// Product meta.
-				foreach ( $product['product_meta'] as $meta ) {
-					$wpdb->query( $wpdb->prepare( "INSERT INTO {$wpdb->postmeta} ( post_id, meta_key, meta_value ) VALUES ( %d, %s, %s )", $product_id, sanitize_text_field( $meta['meta_key'] ), sanitize_text_field( $meta['meta_value'] ) ) );
-				}
-
-				$product_type = ! empty( $product['product']['type'] ) ? $product['product']['type'] : 'booking';
-				wp_set_object_terms( $product_id, $product_type, 'product_type' );
-
-				// Resources.
-				if ( ! empty( $product['resources'] ) ) {
-					$resource_base_costs      = get_post_meta( $product_id, '_resource_base_costs', true );
-					$new_resource_base_costs  = array();
-					$resource_block_costs     = get_post_meta( $product_id, '_resource_block_costs', true );
-					$new_resource_block_costs = array();
-
-					foreach ( $product['resources'] as $resource ) {
-						$resource_data = array( 
-							'post_title'  => sanitize_text_field( $resource['resource']['post_title'] ) . ' (resource test #' . absint( $resource['resource']['ID'] ) . ')',
-							'post_type'   => 'bookable_resource',
-							'post_status' => 'publish',
-						);
-
-						$resource_id = wp_insert_post( $resource_data, false );
-
-						if ( empty( $resource_id ) ) {
-							throw new Exception( 'Failed to create resource.' );
-						}
-
-						foreach ( $resource['resource_meta'] as $meta ) {
-							$wpdb->query( $wpdb->prepare( "INSERT INTO {$wpdb->postmeta} ( post_id, meta_key, meta_value ) VALUES ( %d, %s, %s )", $resource_id, sanitize_text_field( $meta['meta_key'] ), sanitize_text_field( $meta['meta_value'] ) ) );		
-						}
-
-						$new_resource_base_costs[ $resource_id ]  = ! empty( $resource_base_costs[ $resource['resource']['ID'] ] ) ? $resource_base_costs[ $resource['resource']['ID'] ] : '';
-						$new_resource_block_costs[ $resource_id ] = ! empty( $resource_block_costs[ $resource['resource']['ID'] ] ) ? $resource_block_costs[ $resource['resource']['ID'] ] : '';
-						$wpdb->query( $wpdb->prepare( "INSERT INTO {$wpdb->prefix}wc_booking_relationships ( product_id, resource_id ) VALUES ( %d, %d )", $product_id, $resource_id ) );
-					}
-
-					if ( ! empty( $new_resource_base_costs ) ) {
-						update_post_meta( $product_id, '_resource_base_costs', $new_resource_base_costs );
-					}
-
-					if ( ! empty( $new_resource_block_costs ) ) {
-						update_post_meta( $product_id, '_resource_block_costs', $new_resource_block_costs );
-					}
-				}
-
-				// Persons.
-				if ( ! empty( $product['persons'] ) ) {
-					foreach ( $product['persons'] as $person ) {
-						$person_data = array( 
-							'post_title'  => sanitize_text_field( $person['person']['post_title'] ) . ' (person test #' . absint( $person['person']['ID'] ) . ')',
-							'post_type'   => 'bookable_person',
-							'post_status' => 'publish',
-							'post_parent' => absint( $product_id ),
-							'post_excerpt' => sanitize_text_field( $person['person']['post_excerpt'] ),
-						);
-
-						$person_id = wp_insert_post( $person_data, false );
-
-						if ( empty( $person_id ) ) {
-							throw new Exception( 'Failed to create person.' );
-						}
-
-						foreach ( $person['person_meta'] as $meta ) {
-							$wpdb->query( $wpdb->prepare( "INSERT INTO {$wpdb->postmeta} ( post_id, meta_key, meta_value ) VALUES ( %d, %s, %s )", absint( $person_id ), sanitize_text_field( $meta['meta_key'] ), sanitize_text_field( $meta['meta_value'] ) ) );		
-						}
-					}
-				}
-
-				$this->print_notice( 'Booking Product imported successfully!', 'success' );
-				$this->clean_up();
-
-				return;
-			} catch ( Exception $e ) {
-				$this->print_notice( $e->getMessage() );
-
-				return;
-			}
-		}
-
-		/**
-		 * Checks if string is valid JSON.
-		 *
-		 * @since 1.0.0
-		 * @version 1.0.0
-		 * @param string $string
-		 * @return bool
-		 */
-		public function is_json( $string = '' ) {
-			json_decode( $string );
-			
-			return ( JSON_ERROR_NONE === json_last_error() );
-		}
-
-		/**
-		 * Prints notices.
-		 *
-		 * @since 1.0.0
-		 * @version 1.0.0
-		 * @param string $message
-		 * @param string $type
-		 */
-		public function print_notice( $message = '', $type = 'warning' ) {
-			$this->notice = '<div class="notice notice-' . esc_attr( $type ) . '"><p>' . esc_html( $message ) . '</p></div>';
-		}
 	}
 
 	new Bookings_Helper();
+}
+
+add_action( 'plugins_loaded', 'woocommerce_bookings_helper_init', 10 );
+
+function woocommerce_bookings_helper_init() {
+	load_plugin_textdomain( 'bookings-helper', false, plugin_basename( dirname( __FILE__ ) ) . '/languages' );
+
+	if ( ! class_exists( 'WooCommerce' ) ) {
+		add_action( 'admin_notices', 'woocommerce_bookings_missing_wc_notice' );
+
+		return;
+	}
+
+	$GLOBALS['wc_bookings'] = WC_Bookings::instance();
+
 }

--- a/bookings-helper.php
+++ b/bookings-helper.php
@@ -6,8 +6,12 @@
  * Description: This extension is a WooCommerce Bookings helper which helps you to troubleshoot bookings setup easier by allowing you to quickly export/import product settings.
  * Author: WooCommerce
  * Author URI: https://woocommerce.com
- * Requires at least: 4.7.0
- * Tested up to: 5.4.0
+ * Text Domain: bookings-helper
+ * Domain Path: /languages
+ * Tested up to: 6.0.1
+ * Requires at least: 5.6
+ * WC tested up to: 6.3
+ * WC requires at least: 6.0
  *
  * @package WordPress
  * @author WooCommerce

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   },
   "config": {
     "platform": {
-      "php": "7.2"
+      "php": "7.0"
     },
     "allow-plugins": {
       "composer/installers": true,

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,20 @@
+{
+  "name": "woocommerce/bookings-helper",
+  "description": "Troubleshoot bookings setup easier by quickly export/import product settings.",
+  "homepage": "https://woocommerce.com/products/bookings-helper/",
+  "type": "wordpress-plugin",
+  "license": "GPL-2.0+",
+  "require-dev": {
+    "woocommerce/woocommerce-sniffs": "^0.1.3"
+  },
+  "config": {
+    "platform": {
+      "php": "7.2"
+    },
+    "allow-plugins": {
+      "composer/installers": true,
+      "automattic/jetpack-autoloader": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
+  }
+}

--- a/includes/class-wc-bookings-helper-export.php
+++ b/includes/class-wc-bookings-helper-export.php
@@ -1,0 +1,170 @@
+<?php
+
+/**
+ * Class for export functionality.
+ */
+class WC_Booking_Helper_Export extends WC_Bookings_Helper_Utils {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+
+		add_action( 'init', array( $this, 'catch_export_requests' ), 20 );
+	}
+
+	/**
+	 * Catches form requests.
+	 *
+	 * @since 1.0.0
+	 * @version 1.0.0
+	 */
+	public function catch_export_requests() {
+		if ( ! isset( $_GET['page'] ) || 'bookings-helper' !== $_GET['page'] ) {
+			return;
+		}
+
+		if ( ! isset( $_POST['action'] ) || ! isset( $_POST['_wpnonce'] ) ) {
+			return;
+		}
+
+		if (
+			'export_globals' !== $_POST['action'] &&
+			'export_product' !== $_POST['action']
+		) {
+			return;
+		}
+
+		if (
+			! wp_verify_nonce( $_POST['_wpnonce'], 'export_globals' ) &&
+			! wp_verify_nonce( $_POST['_wpnonce'], 'import_globals' ) &&
+			! wp_verify_nonce( $_POST['_wpnonce'], 'export_product' ) &&
+			! wp_verify_nonce( $_POST['_wpnonce'], 'import_product' )
+		) {
+			wp_die( 'Cheatin&#8217; huh?' );
+		}
+
+		switch ( $_POST['action'] ) {
+			case 'export_globals':
+				$this->export_global_rules();
+				break;
+
+			case 'export_product':
+				$this->export_product();
+				break;
+		}
+	}
+
+	/**
+	 * Exports global availability rules file for browser download.
+	 *
+	 * @param 1.0.0
+	 *
+	 * @since 1.0.0
+	 */
+	public function export_global_rules() {
+		try {
+			if ( version_compare( WC_BOOKINGS_VERSION, '1.13.0', '<' ) ) {
+				$global_rules = get_option( 'wc_global_booking_availability', array() );
+			} else {
+				$global_rules = WC_Data_Store::load( 'booking-global-availability' )->get_all_as_array();
+			}
+
+			if ( empty( $global_rules ) ) {
+				throw new Exception( 'There are no rules to export.' );
+			}
+
+			$global_rules_json = json_encode( $global_rules );
+
+			$this->trigger_download( $global_rules_json, 'bookings-global-rules' );
+		} catch ( Exception $e ) {
+			$this->wc_bookings_helper_prepare_notice( $e->getMessage() );
+
+			return;
+		}
+	}
+
+	/**
+	 * Exports a specific product by ID.
+	 *
+	 * @since 1.0.0
+	 * @version 1.0.1
+	 */
+	public function export_product() {
+		try {
+			$product_id     = isset( $_POST['product_id'] ) ? absint( $_POST['product_id'] ) : '';
+			$product_status = get_post_status( $product_id );
+
+			if ( empty( $product_id ) || empty( $product_status ) ) {
+				throw new Exception( 'This booking product does not exist!' );
+			}
+
+			global $wpdb;
+
+			// Products.
+			$product = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->posts} WHERE post_type = 'product' AND ID = %d", $product_id ), ARRAY_A );
+
+			// Get the type of the product, accomm or booking.
+			$product_type       = wp_get_post_terms( $product[0]['ID'], 'product_type' );
+			$product[0]['type'] = $product_type[0]->name;
+
+			if ( empty( $product ) ) {
+				throw new Exception( 'This booking product does not exist!' );
+			}
+
+			// Product metas.
+			$product_meta = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->postmeta} WHERE post_id = %d AND ( meta_key LIKE '%%wc_booking%%' OR meta_key = '_resource_base_costs' OR meta_key = '_resource_block_costs' OR meta_key = '_wc_display_cost' OR meta_key = '_virtual' )", $product_id ), ARRAY_A );
+
+			if ( empty( $product_meta ) ) {
+				throw new Exception( 'This booking product does not exist!' );
+			}
+
+			// Booking relationships ( resources ).
+			$resources = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}wc_booking_relationships WHERE product_id = %d", $product_id ), ARRAY_A );
+
+			$prepared_resources = array();
+			$prepared_persons   = array();
+
+			// If resources exists, we need to extract the meta
+			// information for each resource.
+			if ( ! empty( $resources ) ) {
+				foreach ( $resources as $key => $value ) {
+					$resource = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->posts} WHERE post_type = 'bookable_resource' AND ID = %d", $value['resource_id'] ), ARRAY_A );
+
+					if ( ! empty( $resource ) ) {
+						$resource_meta = $wpdb->get_results( $wpdb->prepare( "SELECT meta_key, meta_value FROM {$wpdb->postmeta} WHERE post_id = %d AND ( meta_key = 'qty' OR meta_key = '_wc_booking_availability' )", $value['resource_id'] ), ARRAY_A );
+					}
+
+					$prepared_resources[] = array( 'resource' => $resource[0], 'resource_meta' => $resource_meta );
+				}
+			}
+
+			// Persons.
+			$persons = $wpdb->get_results( $wpdb->prepare( "SELECT ID, post_title, post_excerpt FROM {$wpdb->posts} WHERE post_type = 'bookable_person' AND post_parent = %d", $product_id ), ARRAY_A );
+
+			if ( ! empty( $persons ) ) {
+				foreach ( $persons as $person ) {
+					$person_meta = $wpdb->get_results( $wpdb->prepare( "SELECT meta_key, meta_value FROM {$wpdb->postmeta} WHERE post_id = %d", $person['ID'] ), ARRAY_A );
+
+					$prepared_persons[] = array( 'person' => $person, 'person_meta' => $person_meta );
+				}
+			}
+
+			$prepared_json = json_encode( array(
+				'product'      => $product[0],
+				'product_meta' => $product_meta,
+				'resources'    => $prepared_resources,
+				'persons'      => $prepared_persons,
+			) );
+
+			$this->trigger_download( $prepared_json, 'booking-product-' . $product_id );
+		} catch ( Exception $e ) {
+			$this->wc_bookings_helper_prepare_notice( $e->getMessage() );
+
+			return;
+		}
+	}
+}
+
+new WC_Booking_Helper_Export();

--- a/includes/class-wc-bookings-helper-import.php
+++ b/includes/class-wc-bookings-helper-import.php
@@ -1,0 +1,275 @@
+<?php
+
+/**
+ * Class for import functionality.
+ */
+class WC_Booking_Helper_Import extends WC_Bookings_Helper_Utils {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+
+		add_action( 'init', array( $this, 'catch_import_requests' ), 20 );
+	}
+
+	/**
+	 * Catches form requests.
+	 *
+	 * @since 1.0.0
+	 * @version 1.0.0
+	 */
+	public function catch_import_requests() {
+		if ( ! isset( $_GET['page'] ) || 'bookings-helper' !== $_GET['page'] ) {
+			return;
+		}
+
+		if ( ! isset( $_POST['action'] ) || ! isset( $_POST['_wpnonce'] ) ) {
+			return;
+		}
+
+		if (
+			'import_globals' !== $_POST['action'] &&
+			'import_product' !== $_POST['action']
+		) {
+			return;
+		}
+
+		if (
+			! wp_verify_nonce( $_POST['_wpnonce'], 'import_globals' ) &&
+			! wp_verify_nonce( $_POST['_wpnonce'], 'import_product' )
+		) {
+			wp_die( 'Cheatin&#8217; huh?' );
+		}
+
+		switch ( $_POST['action'] ) {
+			case 'import_globals':
+				$this->import_global_rules();
+				break;
+
+			case 'import_product':
+				$this->import_product();
+				break;
+		}
+	}
+
+	/**
+	 * Imports global availability rules from file.
+	 *
+	 * @since 1.0.3 Add compatibility with Bookings custom global availability tables.
+	 */
+	public function import_global_rules() {
+		try {
+			if ( empty( $_FILES ) || empty( $_FILES['import'] ) || 0 !== $_FILES['import']['error'] || empty( $_FILES['import']['tmp_name'] ) ) {
+				throw new Exception( 'There are no rules to import or file is not valid.' );
+			} else {
+				if ( $_FILES['import']['size'] > 1000000 ) {
+					throw new Exception( 'The file exceeds 1MB.' );
+				}
+
+				if ( $this->ziparchive_available ) {
+					$global_rules_json = $this->open_zip();
+				} else {
+					$global_rules_json = file_get_contents( $_FILES['import']['tmp_name'] );
+				}
+
+				if ( ! $this->is_json( $global_rules_json ) ) {
+					throw new Exception( 'The file is not in a valid JSON format.' );
+				}
+			}
+
+			$global_rules = json_decode( $global_rules_json, true );
+
+			// Sanitize.
+			array_walk_recursive( $global_rules, 'wc_clean' );
+
+			if ( version_compare( WC_BOOKINGS_VERSION, '1.13.0', '<' ) ) {
+				/*
+				 * For some strange reason update_option is not working here so
+				 * had to revert to delete the option and add it again.
+				 */
+				delete_option( 'wc_global_booking_availability' );
+				add_option( 'wc_global_booking_availability', $global_rules );
+			} else {
+				global $wpdb;
+
+				// First delete all data from table.
+				$wpdb->query( "TRUNCATE TABLE {$wpdb->prefix}wc_bookings_availability" );
+
+				foreach ( $global_rules as $rule ) {
+					$wpdb->insert(
+						$wpdb->prefix . 'wc_bookings_availability',
+						array(
+							'gcal_event_id' => ! empty( $rule['gcal_event_id'] ) ? $rule['gcal_event_id'] : '',
+							'title'         => $rule['title'],
+							'range_type'    => $rule['range_type'],
+							'from_date'     => $rule['from_date'],
+							'to_date'       => $rule['to_date'],
+							'from_range'    => $rule['from_range'],
+							'to_range'      => $rule['to_range'],
+							'bookable'      => $rule['bookable'],
+							'priority'      => $rule['priority'],
+							'ordering'      => $rule['ordering'],
+							'date_created'  => $rule['date_created'],
+							'date_modified' => $rule['date_modified'],
+							'rrule'         => ! empty( $rule['rrule'] ) ? $rule['rrule'] : '',
+						),
+						array(
+							'%s',
+							'%s',
+							'%s',
+							'%s',
+							'%s',
+							'%s',
+							'%s',
+							'%s',
+							'%d',
+							'%d',
+							'%s',
+							'%s',
+						)
+					);
+				}
+			}
+
+			$this->wc_bookings_helper_prepare_notice( 'Global Availability Rules imported successfully!', 'success' );
+			$this->clean_up();
+
+			return;
+		} catch ( Exception $e ) {
+			$this->wc_bookings_helper_prepare_notice( $e->getMessage() );
+
+			return;
+		}
+	}
+
+
+	/**
+	 * Imports booking product from file.
+	 *
+	 * @since 1.0.0
+	 * @version 1.0.1
+	 */
+	public function import_product() {
+		try {
+			if ( empty( $_FILES ) || empty( $_FILES['import'] ) || 0 !== $_FILES['import']['error'] || empty( $_FILES['import']['tmp_name'] ) ) {
+				throw new Exception( 'There is no bookable product to import or file is not valid.' );
+			} else {
+				if ( $_FILES['import']['size'] > 1000000 ) {
+					throw new Exception( 'The file exceeds 1MB.' );
+				}
+
+				if ( $this->ziparchive_available ) {
+					$product_json = $this->open_zip();
+				} else {
+					$product_json = file_get_contents( $_FILES['import']['tmp_name'] );
+				}
+
+				if ( ! $this->is_json( $product_json ) ) {
+					throw new Exception( 'The file is not in a valid JSON format.' );
+				}
+			}
+
+			$product = json_decode( $product_json, true );
+
+			// Sanitize.
+			array_walk_recursive( $product, 'wc_clean' );
+
+			global $wpdb;
+
+			// Product.
+			$product_data = array(
+				'post_title'   => sanitize_text_field( $product['product']['post_title'] ) . ' (bookings test #' . absint( $product['product']['ID'] ) . ')',
+				'post_content' => sanitize_text_field( $product['product']['post_content'] ),
+				'post_type'    => 'product',
+				'post_status'  => 'publish',
+			);
+
+			$product_id = wp_insert_post( $product_data, false );
+
+			if ( empty( $product_id ) ) {
+				throw new Exception( 'Failed to create product.' );
+			}
+
+			// Product meta.
+			foreach ( $product['product_meta'] as $meta ) {
+				$wpdb->query( $wpdb->prepare( "INSERT INTO {$wpdb->postmeta} ( post_id, meta_key, meta_value ) VALUES ( %d, %s, %s )", $product_id, sanitize_text_field( $meta['meta_key'] ), sanitize_text_field( $meta['meta_value'] ) ) );
+			}
+
+			$product_type = ! empty( $product['product']['type'] ) ? $product['product']['type'] : 'booking';
+			wp_set_object_terms( $product_id, $product_type, 'product_type' );
+
+			// Resources.
+			if ( ! empty( $product['resources'] ) ) {
+				$resource_base_costs      = get_post_meta( $product_id, '_resource_base_costs', true );
+				$new_resource_base_costs  = array();
+				$resource_block_costs     = get_post_meta( $product_id, '_resource_block_costs', true );
+				$new_resource_block_costs = array();
+
+				foreach ( $product['resources'] as $resource ) {
+					$resource_data = array(
+						'post_title'  => sanitize_text_field( $resource['resource']['post_title'] ) . ' (resource test #' . absint( $resource['resource']['ID'] ) . ')',
+						'post_type'   => 'bookable_resource',
+						'post_status' => 'publish',
+					);
+
+					$resource_id = wp_insert_post( $resource_data, false );
+
+					if ( empty( $resource_id ) ) {
+						throw new Exception( 'Failed to create resource.' );
+					}
+
+					foreach ( $resource['resource_meta'] as $meta ) {
+						$wpdb->query( $wpdb->prepare( "INSERT INTO {$wpdb->postmeta} ( post_id, meta_key, meta_value ) VALUES ( %d, %s, %s )", $resource_id, sanitize_text_field( $meta['meta_key'] ), sanitize_text_field( $meta['meta_value'] ) ) );
+					}
+
+					$new_resource_base_costs[ $resource_id ]  = ! empty( $resource_base_costs[ $resource['resource']['ID'] ] ) ? $resource_base_costs[ $resource['resource']['ID'] ] : '';
+					$new_resource_block_costs[ $resource_id ] = ! empty( $resource_block_costs[ $resource['resource']['ID'] ] ) ? $resource_block_costs[ $resource['resource']['ID'] ] : '';
+					$wpdb->query( $wpdb->prepare( "INSERT INTO {$wpdb->prefix}wc_booking_relationships ( product_id, resource_id ) VALUES ( %d, %d )", $product_id, $resource_id ) );
+				}
+
+				if ( ! empty( $new_resource_base_costs ) ) {
+					update_post_meta( $product_id, '_resource_base_costs', $new_resource_base_costs );
+				}
+
+				if ( ! empty( $new_resource_block_costs ) ) {
+					update_post_meta( $product_id, '_resource_block_costs', $new_resource_block_costs );
+				}
+			}
+
+			// Persons.
+			if ( ! empty( $product['persons'] ) ) {
+				foreach ( $product['persons'] as $person ) {
+					$person_data = array(
+						'post_title'   => sanitize_text_field( $person['person']['post_title'] ) . ' (person test #' . absint( $person['person']['ID'] ) . ')',
+						'post_type'    => 'bookable_person',
+						'post_status'  => 'publish',
+						'post_parent'  => absint( $product_id ),
+						'post_excerpt' => sanitize_text_field( $person['person']['post_excerpt'] ),
+					);
+
+					$person_id = wp_insert_post( $person_data, false );
+
+					if ( empty( $person_id ) ) {
+						throw new Exception( 'Failed to create person.' );
+					}
+
+					foreach ( $person['person_meta'] as $meta ) {
+						$wpdb->query( $wpdb->prepare( "INSERT INTO {$wpdb->postmeta} ( post_id, meta_key, meta_value ) VALUES ( %d, %s, %s )", absint( $person_id ), sanitize_text_field( $meta['meta_key'] ), sanitize_text_field( $meta['meta_value'] ) ) );
+					}
+				}
+			}
+
+			$this->wc_bookings_helper_prepare_notice( 'Booking Product imported successfully!', 'success' );
+			$this->clean_up();
+
+			return;
+		} catch ( Exception $e ) {
+			$this->wc_bookings_helper_prepare_notice( $e->getMessage() );
+
+			return;
+		}
+	}
+}
+
+new WC_Booking_Helper_Import();

--- a/includes/class-wc-bookings-helper-utils.php
+++ b/includes/class-wc-bookings-helper-utils.php
@@ -1,0 +1,263 @@
+<?php
+
+/**
+ * Class for util functions.
+ */
+class WC_Bookings_Helper_Utils {
+	/**
+	 * Notices.
+	 *
+	 * @since 1.0.4
+	 * @var
+	 */
+	private $notice = '';
+	/**
+	 * Temporary directory path.
+	 *
+	 * @since 1.0.2
+	 * @version 1.0.2
+	 * @var
+	 */
+	public $temp_dir;
+
+	/**
+	 * Checks to see if ZipArchive library exists.
+	 *
+	 * @since 1.0.2
+	 * @version 1.0.2
+	 * @var
+	 */
+	public $ziparchive_available;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->temp_dir             = get_temp_dir() . 'bookings-helper';
+		$this->ziparchive_available = class_exists( 'ZipArchive' );
+
+		add_action( 'admin_notices', array( $this, 'wc_bookings_helper_show_notice' ) );
+	}
+
+	/**
+	 * Prints notices.
+	 *
+	 * @param string $message
+	 * @param string $type
+	 *
+	 * @since 1.0.0
+	 * @version 1.0.0
+	 */
+	public function wc_bookings_helper_prepare_notice( $message = '', $type = 'warning' ) {
+		$this->notice = '<div class="notice notice-' . esc_attr( $type ) . '"><p>' . esc_html( $message ) . '</p></div>';
+	}
+
+	/**
+	 * Prints notices.
+	 *
+	 * @param string $message
+	 * @param string $type
+	 *
+	 * @since 1.0.0
+	 * @version 1.0.0
+	 */
+	public function wc_bookings_helper_show_notice() {
+		if ( ! empty( $this->notice ) ) {
+			echo $this->notice;
+		}
+	}
+
+	/**
+	 * Cleans up lingering files and folder during transfer.
+	 *
+	 * @since 1.0.2
+	 * @version 1.0.2
+	 */
+	public function clean_up( $path = null ) {
+		if ( null === $path ) {
+			$path = $this->temp_dir;
+		}
+
+		if ( is_dir( $path ) ) {
+			$objects = scandir( $path );
+
+			foreach ( $objects as $object ) {
+				if ( '.' !== $object && '..' !== $object ) {
+					if ( is_dir( $path . '/' . $object ) ) {
+						$this->clean_up( $path . '/' . $object );
+					} else {
+						unlink( $path . '/' . $object );
+					}
+				}
+			}
+
+			rmdir( $path );
+		}
+	}
+
+	/**
+	 * Creates the zip file.
+	 *
+	 * @param JSON string $data | Data to be zipped
+	 * @param string $filename
+	 *
+	 * @since 1.0.2
+	 * @version 1.0.2
+	 */
+	public function create_zip( $data = false, $filename ) {
+		$zip_file = $this->temp_dir . '/' . $filename . '.zip';
+
+		$zip = new ZipArchive();
+		$zip->open( $zip_file, ZIPARCHIVE::CREATE | ZIPARCHIVE::OVERWRITE );
+		$zip->addFromString( $filename . '.json', $data );
+		$zip->close();
+
+		if ( file_exists( $this->temp_dir . '/' . $filename . '.zip' ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Triggers the download feature of the browser.
+	 *
+	 * @param string $data
+	 * @param string $prefix
+	 *
+	 * @since 1.0.0
+	 * @version 1.0.0
+	 */
+	public function trigger_download( $data = '', $prefix = '' ) {
+		if ( empty( $data ) ) {
+			return;
+		}
+
+		@set_time_limit( 0 );
+
+		// Disable GZIP
+		if ( function_exists( 'apache_setenv' ) ) {
+			@apache_setenv( 'no-gzip', 1 );
+		}
+
+		@ini_set( 'zlib.output_compression', 'Off' );
+		@ini_set( 'output_buffering', 'Off' );
+		@ini_set( 'output_handler', '' );
+
+		$filename_prefix = $prefix;
+
+		if ( $this->ziparchive_available ) {
+			$filename = sprintf( '%1$s-%2$s', $filename_prefix, date( 'Y-m-d', current_time( 'timestamp' ) ) );
+
+			$this->prep_transfer();
+
+			$this->render_headers( $filename );
+
+			if ( $this->create_zip( $data, $filename ) ) {
+				readfile( $this->temp_dir . '/' . $filename . '.zip' );
+
+				$this->clean_up();
+
+				exit;
+			} else {
+				throw new Exception( 'Unable to export!' );
+			}
+		} else {
+			$filename = sprintf( '%1$s-%2$s.json', $filename_prefix, date( 'Y-m-d', current_time( 'timestamp' ) ) );
+
+			$this->render_headers( $filename );
+
+			file_put_contents( 'php://output', $data );
+
+			exit;
+		}
+	}
+
+	/**
+	 * Opens the zip file.
+	 *
+	 * @since 1.0.2
+	 * @version 1.0.2
+	 */
+	public function open_zip() {
+		$zip = new ZipArchive();
+
+		if ( true === $zip->open( $_FILES['import']['tmp_name'] ) ) {
+			$zip->extractTo( $this->temp_dir );
+			$zip->close();
+
+			$dir       = scandir( $this->temp_dir );
+			$json_file = '';
+
+			/**
+			 * The zip may or may not contain other hidden
+			 * system files so we must only extract the .json file.
+			 */
+			foreach ( $dir as $file ) {
+				if ( preg_match( '/.json/', $file ) ) {
+					$json_file = $file;
+					break;
+				}
+			}
+
+			if ( ! file_exists( $this->temp_dir . '/' . $json_file ) ) {
+				throw new Exception( 'Unable to open zip file' );
+			}
+
+			return file_get_contents( $this->temp_dir . '/' . $json_file );
+		} else {
+			throw new Exception( 'Unable to open zip file' );
+		}
+	}
+
+	/**
+	 * Prepares the directory for file transfer.
+	 *
+	 * @since 1.0.2
+	 * @version 1.0.2
+	 */
+	public function prep_transfer() {
+		if ( ! is_dir( $this->temp_dir ) ) {
+			return mkdir( $this->temp_dir );
+		}
+	}
+
+
+	/**
+	 * Renders the HTTP headers
+	 *
+	 * @param string $filename | Path to file
+	 *
+	 * @version 1.0.2
+	 * @since 1.0.2
+	 */
+	public function render_headers( $filename ) {
+		$type = 'json';
+
+		if ( $this->ziparchive_available ) {
+			$type = 'zip';
+		}
+
+		header( 'Content-Type: application/' . $type . '; charset=UTF-8' );
+		header( 'Content-Disposition: attachment; filename=' . $filename . '.' . $type );
+		header( 'Pragma: no-cache' );
+		header( 'Expires: 0' );
+	}
+
+	/**
+	 * Checks if string is valid JSON.
+	 *
+	 * @param string $string
+	 *
+	 * @return bool
+	 * @since 1.0.0
+	 * @version 1.0.0
+	 */
+	public function is_json( $string = '' ) {
+		json_decode( $string );
+
+		return ( JSON_ERROR_NONE === json_last_error() );
+	}
+}
+
+new WC_Bookings_Helper_Utils();

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress Coding Standards">
+    <rule ref="Extendables">
+    </rule>
+
+    <!-- Files to check -->
+    <arg name="extensions" value="php"/>
+    <file>.</file>
+
+    <exclude-pattern>*/node_modules/*</exclude-pattern>
+    <exclude-pattern>*/vendor/*</exclude-pattern>
+    <exclude-pattern>*/tests/*</exclude-pattern>
+
+    <!-- ensure we are using language features according to supported PHP versions -->
+    <config name="testVersion" value="7.2-"/>
+    <rule ref="PHPCompatibilityWP" />
+</ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -12,6 +12,6 @@
     <exclude-pattern>*/tests/*</exclude-pattern>
 
     <!-- ensure we are using language features according to supported PHP versions -->
-    <config name="testVersion" value="7.2-"/>
+    <config name="testVersion" value="7.0-"/>
     <rule ref="PHPCompatibilityWP" />
 </ruleset>


### PR DESCRIPTION
## Changes made in this PR:

* This PR re-structures the entire plugin and separates the codes intro relative class files.
* Cleans up the code from the plugin.
* Standardized the code, use escaping functions.
* Makes strings translatable.
* Adds new files: `compsoer.json`, `phpcs.xml`, `.gitignore`.
* Adds a PHPCS Compatibility testing Github Action.
* Bumps min versions: WordPress to 5.6,  WooCommerce to 6.0, PHP to 7.0

Closes #21, Closes #22, Closes #23.

