### PR TITLE
Enhancement/26 Ability of importing Product & Global Rules via single zip

### DIFF
--- a/includes/class-wc-bookings-helper-import.php
+++ b/includes/class-wc-bookings-helper-import.php
@@ -204,7 +204,12 @@ class WC_Bookings_Helper_Import extends WC_Bookings_Helper_Utils {
 
 			// Product meta.
 			foreach ( $product['product_meta'] as $meta ) {
-				add_post_meta( $product_id, sanitize_text_field( $meta['meta_key'] ), sanitize_text_field( $meta['meta_value'] ) );
+				// Skip Double serialization.
+				if ( is_serialized( $meta['meta_value'] ) ) {
+					$wpdb->query( $wpdb->prepare( "INSERT INTO {$wpdb->postmeta} ( post_id, meta_key, meta_value ) VALUES ( %d, %s, %s )", $product_id, sanitize_text_field( $meta['meta_key'] ), sanitize_text_field( $meta['meta_value'] ) ) );
+				} else {
+					add_post_meta( $product_id, sanitize_text_field( $meta['meta_key'] ), sanitize_text_field( $meta['meta_value'] ) );
+				}
 			}
 
 			$product_type = ! empty( $product['product']['type'] ) ? $product['product']['type'] : 'booking';
@@ -212,9 +217,9 @@ class WC_Bookings_Helper_Import extends WC_Bookings_Helper_Utils {
 
 			// Resources.
 			if ( ! empty( $product['resources'] ) ) {
-				$resource_base_costs      = unserialize( get_post_meta( $product_id, '_resource_base_costs', true ) );
+				$resource_base_costs      = get_post_meta( $product_id, '_resource_base_costs', true );
 				$new_resource_base_costs  = array();
-				$resource_block_costs     = unserialize( get_post_meta( $product_id, '_resource_block_costs', true ) );
+				$resource_block_costs     = get_post_meta( $product_id, '_resource_block_costs', true );
 				$new_resource_block_costs = array();
 
 				foreach ( $product['resources'] as $resource ) {

--- a/includes/class-wc-bookings-helper-import.php
+++ b/includes/class-wc-bookings-helper-import.php
@@ -59,6 +59,7 @@ class WC_Bookings_Helper_Import extends WC_Bookings_Helper_Utils {
 	 *
 	 * @since 1.0.3 Add compatibility with Bookings custom global availability tables.
 	 * @throws Exception Show error if file isn't valid.
+	 * @param string $global_rules_form_product_zip Global rules to import.
 	 */
 	public function import_global_rules( $global_rules_form_product_zip = '' ) {
 		try {
@@ -138,7 +139,7 @@ class WC_Bookings_Helper_Import extends WC_Bookings_Helper_Utils {
 				}
 			}
 
-			if( ! empty( $global_rules_form_product_zip ) ) {
+			if ( ! empty( $global_rules_form_product_zip ) ) {
 				return;
 			}
 
@@ -152,7 +153,6 @@ class WC_Bookings_Helper_Import extends WC_Bookings_Helper_Utils {
 			return;
 		}
 	}
-
 
 	/**
 	 * Imports booking product from file.
@@ -204,7 +204,7 @@ class WC_Bookings_Helper_Import extends WC_Bookings_Helper_Utils {
 
 			// Product meta.
 			foreach ( $product['product_meta'] as $meta ) {
-				// Skip Double serialization.
+				// Skip double serialization.
 				if ( is_serialized( $meta['meta_value'] ) ) {
 					$wpdb->query( $wpdb->prepare( "INSERT INTO {$wpdb->postmeta} ( post_id, meta_key, meta_value ) VALUES ( %d, %s, %s )", $product_id, sanitize_text_field( $meta['meta_key'] ), sanitize_text_field( $meta['meta_value'] ) ) );
 				} else {
@@ -278,13 +278,13 @@ class WC_Bookings_Helper_Import extends WC_Bookings_Helper_Utils {
 
 			$success_message = __( 'Booking Product imported successfully!', 'bookings-helper' );
 
-			// Import Global rules.
+			// Import global rules.
 			if ( isset( $_POST['include_global_rules'] ) && ! empty( $product['global_rules'] ) ) {
 				$this->import_global_rules( $product['global_rules'] );
 				$success_message = __( 'Booking Product and Global rules imported successfully!', 'bookings-helper' );
 			}
 
-			$this->wc_bookings_helper_prepare_notice( esc_html( $success_message ) , 'success' );
+			$this->wc_bookings_helper_prepare_notice( esc_html( $success_message ), 'success' );
 			$this->clean_up();
 
 			return;

--- a/templates/tool-page.php
+++ b/templates/tool-page.php
@@ -74,12 +74,12 @@ $file_label           = $ziparchive_available ? 'ZIP' : 'JSON';
 							<label><?php esc_html_e( 'Choose a file', 'bookings-helper' ); ?> (<?php echo esc_html( $file_label ); ?>).</label><input type="file" name="import"/>
 						</td>
 					</tr>
-                    <tr>
-                        <td>
-                            <input type="checkbox" id="include_global_rules" name="include_global_rules" style="margin:10px 0;"/>
-                            <label for="include_global_rules"><?php esc_html_e( 'Also import Global rules.', 'bookings-helper' ); ?></label>
-                        </td>
-                    </tr>
+					<tr>
+						<td>
+							<input type="checkbox" id="include_global_rules" name="include_global_rules" style="margin:10px 0;"/>
+							<label for="include_global_rules"><?php esc_html_e( 'Import global availability rules (if your ZIP contains those) replacing your current rules.', 'bookings-helper' ); ?></label>
+						</td>
+					</tr>
 					<tr>
 						<td>
 							<input type="submit" class="button" value="<?php esc_attr_e( 'Import Product', 'bookings-helper' ); ?>"/> <label><?php esc_html_e( 'Imports a booking product.', 'bookings-helper' ); ?></label>

--- a/templates/tool-page.php
+++ b/templates/tool-page.php
@@ -74,7 +74,12 @@ $file_label           = $ziparchive_available ? 'ZIP' : 'JSON';
 							<label><?php esc_html_e( 'Choose a file', 'bookings-helper' ); ?> (<?php echo esc_html( $file_label ); ?>).</label><input type="file" name="import"/>
 						</td>
 					</tr>
-
+                    <tr>
+                        <td>
+                            <input type="checkbox" id="include_global_rules" name="include_global_rules" style="margin:10px 0;"/>
+                            <label for="include_global_rules"><?php esc_html_e( 'Also import Global rules.', 'bookings-helper' ); ?></label>
+                        </td>
+                    </tr>
 					<tr>
 						<td>
 							<input type="submit" class="button" value="<?php esc_attr_e( 'Import Product', 'bookings-helper' ); ?>"/> <label><?php esc_html_e( 'Imports a booking product.', 'bookings-helper' ); ?></label>


### PR DESCRIPTION
This is a helping enhancement to the main export feature introduced in https://github.com/woocommerce/woocommerce-bookings/pull/3386.

Also, a checkbox is added (unticked by default) to allow users to determine if global rules should "also" be imported along with the product.

![image](https://user-images.githubusercontent.com/25176325/182828218-c9dc0722-aebe-4f18-b93f-c25312b0670b.png)
[image link](https://www.screencast.com/t/LVGiZw58)

Note:
While testing, a few warnings (all same) were seen under the "Cost" tab, which is also fixed by this PR.

```
Warning: Illegal string offset 'type' in ../plugins/woocommerce-bookings/includes/admin/views/html-booking-pricing-fields.php
```

Closes #26.

## Steps to test:

This is a helping PR of https://github.com/woocommerce/woocommerce-bookings/pull/3386 so it will be tested along with it. Follow the steps mentioned in that PR.