### PR TITLE
Fix/28 Unserialize the data before importing via `add_post_meta`

### DIFF
--- a/includes/class-wc-bookings-helper-import.php
+++ b/includes/class-wc-bookings-helper-import.php
@@ -236,7 +236,8 @@ class WC_Bookings_Helper_Import extends WC_Bookings_Helper_Utils {
 					}
 
 					foreach ( $resource['resource_meta'] as $meta ) {
-						add_post_meta( $resource_id, sanitize_text_field( $meta['meta_key'] ), sanitize_text_field( $meta['meta_value'] ) );
+						$meta_value = maybe_unserialize( sanitize_text_field( $meta['meta_value'] ) );
+						add_post_meta( $resource_id, sanitize_text_field( $meta['meta_key'] ), $meta_value );
 					}
 
 					$new_resource_base_costs[ $resource_id ]  = ! empty( $resource_base_costs[ $resource['resource']['ID'] ] ) ? $resource_base_costs[ $resource['resource']['ID'] ] : '';


### PR DESCRIPTION
The exported resources meta is in a serialized form and that was being imported directly as it is using the `add_post_meta` functions. That caused double serialization and hence the resource meta was not in the proper form to be used.

The resource availability rules were not displayed on the edit resource page which threw this error:
`CRITICAL Uncaught TypeError: Cannot access offset of type string`

This PR fixes this issue by unserializing the serialized data before importing.

## Steps o test:
1. Import the product: [https://d.pr/f/KDLyCm](https://href.li/?https://d.pr/f/KDLyCm)
2. Visit the imported resource's edit screen.
3. See the availability rules displayed and there are no errors/warnings.