### PR TITLE
Prevented a fatal error and added a GitHub Action to generate and upload a ZIP file to the release.

### DIFF
--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -1,0 +1,30 @@
+name: Generate ZIP file
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+    generate-zip-file:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+            - name: Set PHP version
+              uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
+              with:
+                php-version: 7.4
+                tools: composer:v2
+
+            - name: Install and build
+              run: |
+                  composer install --no-dev -o
+                  composer archive --format=zip --file=bookings-helper
+                  rm -rf ./bookings-helper && unzip bookings-helper.zip -d ./bookings-helper
+
+            - name: Use the Upload Artifact GitHub Action
+              uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+              with:
+                  name: bookings-helper
+                  path: bookings-helper/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Publish Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  tag:
+    name: New release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set PHP version
+        uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
+        with:
+          php-version: 7.4
+          tools: composer:v2
+
+      - name: Install and build
+        run: |
+            composer install --no-dev -o
+            composer archive --format=zip --file=bookings-helper
+
+      - name: Upload release asset
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
+        with:
+          files: ./bookings-helper.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/bookings-helper.php
+++ b/bookings-helper.php
@@ -93,7 +93,18 @@ if ( ! class_exists( 'Bookings_Helper' ) ) {
 	}
 }
 
-require_once 'vendor/autoload.php';
+// Require the autoloader if it exists.
+if ( file_exists( plugin_dir_path( __FILE__ ) . '/vendor/autoload.php' ) ) {
+	require_once plugin_dir_path( __FILE__ ) . '/vendor/autoload.php';
+} else {
+	add_action( 'admin_notices', function () {
+		?>
+		<div class="notice notice-error">
+			<p><?php esc_html_e( 'Please run "composer install" in the "Bookings Helper" plugin directory.', 'bookings-helper' ); ?></p>
+		</div>
+		<?php
+	} );
+}
 
 /**
  * WooCommerce fallback notice.

--- a/bookings-helper.php
+++ b/bookings-helper.php
@@ -97,13 +97,16 @@ if ( ! class_exists( 'Bookings_Helper' ) ) {
 if ( file_exists( plugin_dir_path( __FILE__ ) . '/vendor/autoload.php' ) ) {
 	require_once plugin_dir_path( __FILE__ ) . '/vendor/autoload.php';
 } else {
-	add_action( 'admin_notices', function () {
-		?>
-		<div class="notice notice-error">
-			<p><?php esc_html_e( 'Please run "composer install" in the "Bookings Helper" plugin directory.', 'bookings-helper' ); ?></p>
-		</div>
-		<?php
-	} );
+	add_action(
+		'admin_notices',
+		function () {
+			?>
+			<div class="notice notice-error">
+				<p><?php esc_html_e( 'Please run "composer install" in the "Bookings Helper" plugin directory.', 'bookings-helper' ); ?></p>
+			</div>
+			<?php
+		}
+	);
 }
 
 /**

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,12 @@
   },
   "archive": {
     "exclude": [
-      "!vendor"
+      "!vendor",
+      ".github",
+      ".gitignore",
+      "composer.json",
+      "composer.lock",
+      "phpcs.xml"
     ]
   },
   "require": {


### PR DESCRIPTION
### Changes proposed in this Pull Request:  

As reported in #44, the bookings helper plugin throws a fatal error during activation. Upon investigating the root cause, I discovered that in the 1.0.6 release, we added the vendor autoloader. As a result, an error occurs if the `vendor` directory is missing.  

This PR adds a condition to load the autoloader only if it exists and displays a notice prompting users to run `composer install` if the `vendor` directory is not present. Additionally, this PR adds a GitHub Action to generate a ZIP file and upload the build ZIP to the release, allowing users to generate a build ZIP for a specific branch.

Closes #44 

### Steps to test the changes in this Pull Request:  

1. Install the plugin without running `composer install`.  
2. Verify that the plugin does not throw a fatal error but instead displays a notice prompting users to run `composer install`.  
3. **GitHub Actions:** GitHub Actions can only be tested after this PR is merged. Testing the release GitHub Action would require a new release. I have tested this PR on a forked repository, and it works as expected.  

### Changelog entry  
> Dev - Prevented a fatal error and added a GitHub Action to generate and upload a ZIP file to the release.